### PR TITLE
Add transformStrokeAndFill property to fabric.Path

### DIFF
--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -67,6 +67,13 @@
     minY: 0,
 
     /**
+     * When false, the stroke will always drawn the same width, regardless of scaleX and scaleY.
+     * @type Boolean
+     * @default
+     */
+    transformStrokeAndFill: true,
+
+    /**
      * Constructor
      * @param {Array|String} path Path data (sequence of coordinates and corresponding "command" tokens)
      * @param {Object} [options] Options object
@@ -117,9 +124,9 @@
 
     /**
      * @private
-     * @param {CanvasRenderingContext2D} ctx context to render path on
+     * @param {CanvasRenderingContext2D} ctx context to create path on
      */
-    _render: function(ctx) {
+    _createPath: function(ctx) {
       var current, // current instruction
           previous = null,
           subpathStartX = 0,
@@ -424,6 +431,9 @@
         }
         previous = current;
       }
+    },
+
+    _renderCurrentPath: function(ctx) {
       this._renderFill(ctx);
       this._renderStroke(ctx);
     },
@@ -441,22 +451,26 @@
 
       ctx.save();
 
-      this._setupCompositeOperation(ctx);
+      !this.transformStrokeAndFill && ctx.save();
       if (!noTransform) {
         this.transform(ctx);
       }
-      this._setStrokeStyles(ctx);
-      this._setFillStyles(ctx);
       if (this.group && this.group.type === 'path-group') {
         ctx.translate(-this.group.width / 2, -this.group.height / 2);
       }
       if (this.transformMatrix) {
         ctx.transform.apply(ctx, this.transformMatrix);
       }
+      this._createPath(ctx, noTransform);
+      !this.transformStrokeAndFill && ctx.restore();
+
+      this._setupCompositeOperation(ctx);
+      this._setStrokeStyles(ctx);
+      this._setFillStyles(ctx);
       this._setOpacity(ctx);
       this._setShadow(ctx);
       this.clipTo && fabric.util.clipContext(this, ctx);
-      this._render(ctx, noTransform);
+      this._renderCurrentPath(ctx);
       this.clipTo && ctx.restore();
       this._removeShadow(ctx);
       this._restoreCompositeOperation(ctx);


### PR DESCRIPTION
This allows the stroke to be rendered without scaling.
