### PR TITLE
[#90860216] Hack around stroke scaling for Ellipse, Polygon and Path

### DIFF
--- a/src/shapes/ellipse.class.js
+++ b/src/shapes/ellipse.class.js
@@ -42,6 +42,13 @@
     ry:   0,
 
     /**
+     * When false, the stroke will always drawn the same width, regardless of scaleX and scaleY.
+     * @type Boolean
+     * @default
+     */
+    transformStrokeAndFill: true,
+
+    /**
      * Constructor
      * @param {Object} [options] Options object
      * @return {fabric.Ellipse} thisArg
@@ -139,7 +146,7 @@
      * @param {CanvasRenderingContext2D} ctx context to render on
      * @param {Boolean} [noTransform] When true, context is not transformed
      */
-    _render: function(ctx, noTransform) {
+    _createPath: function(ctx, noTransform) {
       ctx.beginPath();
       ctx.save();
       ctx.transform(1, 0, 0, this.ry/this.rx, 0, 0);
@@ -151,8 +158,59 @@
         piBy2,
         false);
       ctx.restore();
+    },
+
+    _renderCurrentPath: function(ctx) {
       this._renderFill(ctx);
       this._renderStroke(ctx);
+    },
+
+    /**
+     * Renders an object on a specified context
+     * @param {CanvasRenderingContext2D} ctx Context to render on
+     * @param {Boolean} [noTransform] When true, context is not transformed
+     */
+    render: function(ctx, noTransform) {
+      // do not render if width/height are zeros or object is not visible
+      if (this.width === 0 || this.height === 0 || !this.visible) {
+        return;
+      }
+
+      ctx.save();
+
+      !this.transformStrokeAndFill && ctx.save();
+      if (!noTransform) {
+        this.transform(ctx);
+      }
+      if (this.group && this.group.type === 'path-group') {
+        ctx.translate(-this.group.width / 2, -this.group.height / 2);
+      }
+      if (this.transformMatrix) {
+        ctx.transform.apply(ctx, this.transformMatrix);
+      }
+      this._createPath(ctx, noTransform);
+      !this.transformStrokeAndFill && ctx.restore();
+
+      // Pop contexts to remove scaling applied by the PathGroup
+      if (!this.transformStrokeAndFill && this.group && this.group.type === 'path-group') {
+        ctx.restore();  // ctx.save at the top of this function.
+        ctx.restore();  // ctx.save in PathGroup - we're not distorted now. PathGroup has been hacked to expect this.
+        ctx.save();     // Make a new context so PathGroup has something to restore.
+        ctx.save();     // Emulate ctx.save at the top of this function
+      }
+
+      this._setupCompositeOperation(ctx);
+      this._setStrokeStyles(ctx);
+      this._setFillStyles(ctx);
+      this._setOpacity(ctx);
+      this._setShadow(ctx);
+      this.clipTo && fabric.util.clipContext(this, ctx);
+      this._renderCurrentPath(ctx);
+      this.clipTo && ctx.restore();
+      this._removeShadow(ctx);
+      this._restoreCompositeOperation(ctx);
+
+      ctx.restore();
     },
 
     /**

--- a/src/shapes/path_group.class.js
+++ b/src/shapes/path_group.class.js
@@ -76,23 +76,20 @@
         return;
       }
 
-      ctx.save();
-
-      var m = this.transformMatrix;
-
-      if (m) {
-        ctx.transform(m[0], m[1], m[2], m[3], m[4], m[5]);
-      }
-      this.transform(ctx);
-
-      this._setShadow(ctx);
-      this.clipTo && fabric.util.clipContext(this, ctx);
       for (var i = 0, l = this.paths.length; i < l; ++i) {
+        ctx.save();
+
+        var m = this.transformMatrix;
+
+        if (m) {
+          ctx.transform(m[0], m[1], m[2], m[3], m[4], m[5]);
+        }
+        this.transform(ctx);
+
         this.paths[i].render(ctx, true);
+
+        ctx.restore();
       }
-      this.clipTo && ctx.restore();
-      this._removeShadow(ctx);
-      ctx.restore();
     },
 
     /**

--- a/src/shapes/polygon.class.js
+++ b/src/shapes/polygon.class.js
@@ -50,6 +50,13 @@
     minY: 0,
 
     /**
+     * When false, the stroke will always drawn the same width, regardless of scaleX and scaleY.
+     * @type Boolean
+     * @default
+     */
+    transformStrokeAndFill: true,
+
+    /**
      * Constructor
      * @param {Array} points Array of points
      * @param {Object} [options] Options object
@@ -140,8 +147,11 @@
      * @private
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
-    _render: function(ctx) {
+    _createPath: function(ctx) {
       this.commonRender(ctx);
+    },
+
+    _renderCurrentPath: function(ctx) {
       this._renderFill(ctx);
       if (this.stroke || this.strokeDashArray) {
         ctx.closePath();
@@ -178,6 +188,54 @@
     _renderDashedStroke: function(ctx) {
       fabric.Polyline.prototype._renderDashedStroke.call(this, ctx);
       ctx.closePath();
+    },
+
+    /**
+     * Renders an object on a specified context
+     * @param {CanvasRenderingContext2D} ctx Context to render on
+     * @param {Boolean} [noTransform] When true, context is not transformed
+     */
+    render: function(ctx, noTransform) {
+      // do not render if width/height are zeros or object is not visible
+      if (this.width === 0 || this.height === 0 || !this.visible) {
+        return;
+      }
+
+      ctx.save();
+
+      !this.transformStrokeAndFill && ctx.save();
+      if (!noTransform) {
+        this.transform(ctx);
+      }
+      if (this.group && this.group.type === 'path-group') {
+        ctx.translate(-this.group.width / 2, -this.group.height / 2);
+      }
+      if (this.transformMatrix) {
+        ctx.transform.apply(ctx, this.transformMatrix);
+      }
+      this._createPath(ctx, noTransform);
+      !this.transformStrokeAndFill && ctx.restore();
+
+      // Pop contexts to remove scaling applied by the PathGroup
+      if (!this.transformStrokeAndFill && this.group && this.group.type === 'path-group') {
+        ctx.restore();  // ctx.save at the top of this function.
+        ctx.restore();  // ctx.save in PathGroup - we're not distorted now. PathGroup has been hacked to expect this.
+        ctx.save();     // Make a new context so PathGroup has something to restore.
+        ctx.save();     // Emulate ctx.save at the top of this function
+      }
+
+      this._setupCompositeOperation(ctx);
+      this._setStrokeStyles(ctx);
+      this._setFillStyles(ctx);
+      this._setOpacity(ctx);
+      this._setShadow(ctx);
+      this.clipTo && fabric.util.clipContext(this, ctx);
+      this._renderCurrentPath(ctx);
+      this.clipTo && ctx.restore();
+      this._removeShadow(ctx);
+      this._restoreCompositeOperation(ctx);
+
+      ctx.restore();
     },
 
     /**


### PR DESCRIPTION
This is super awful.

The whole rendering pipeline in Fabric should be re-worked to understand the state stack and be able to seamlessly restore to the canvas-level context and then re-apply all transformations. That's not a thread I'm going to pull on right now...
