### PR TITLE
[#93583156] Stop propagation of keydown events from textarea

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -126,6 +126,8 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       this[this._ctrlKeysMap[e.keyCode]](e);
     }
     else {
+      // Prevent other keydown handlers from calling preventDefault() on events the textarea needs to receive, like arrows and backspace.
+      e.stopPropagation();
       return;
     }
     e.stopImmediatePropagation();


### PR DESCRIPTION
This allows the textarea to receive arrow and backspace keypresses.
