### PR TITLE
Make textarea look more like Fabric rendering.

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -9,7 +9,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     this.hiddenTextarea = fabric.document.createElement('textarea');
     this.hiddenTextarea.value = this.text;
 
-    this.hiddenTextarea.style.cssText = 'position: absolute; overflow: hidden; resize: none; margin: 0; padding: 0; border: 0; box-shadow: none; border-radius: 0;';
+    this.hiddenTextarea.style.cssText = 'position: absolute; overflow: hidden; resize: none; margin: 0; margin-top: -4px; padding: 0; border: 0; box-shadow: none; border-radius: 0; background-color: transparent;';
     //If at all possible, show the textarea within the canvas wrapper where it can exist
     //at the same height as the iText display. This prevents iOS from scrolling to whatever
     //height the textarea is at when you type.
@@ -79,7 +79,8 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       this.hiddenTextarea.style.fontSize = this.fontSize * xScale + 'px';
       this.hiddenTextarea.style.color = this.fill;
       this.hiddenTextarea.style.textAlign = this.textAlign;
-      this.hiddenTextarea.style.lineHeight = this.lineHeight;
+      this.hiddenTextarea.style.lineHeight = this.lineHeight * this._fontSizeMult;
+
     }
   },
 

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -9,7 +9,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     this.hiddenTextarea = fabric.document.createElement('textarea');
     this.hiddenTextarea.value = this.text;
 
-    this.hiddenTextarea.style.cssText = 'position: absolute; overflow: hidden; resize: none; margin: 0; margin-top: -4px; padding: 0; border: 0; box-shadow: none; border-radius: 0; background-color: transparent;';
+    this.hiddenTextarea.style.cssText = 'position: absolute; overflow: hidden; resize: none; margin: 0; padding: 0; border: 0; box-shadow: none; border-radius: 0; background-color: transparent;';
     //If at all possible, show the textarea within the canvas wrapper where it can exist
     //at the same height as the iText display. This prevents iOS from scrolling to whatever
     //height the textarea is at when you type.

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -319,34 +319,7 @@
      * Renders cursor or selection (depending on what exists)
      */
     renderCursorOrSelection: function() {
-      if (!this.active) {
-        return;
-      }
-
-      var chars = this.text.split(''),
-          boundaries, ctx;
-
-      if (this.canvas.contextTop) {
-        ctx = this.canvas.contextTop;
-        ctx.save();
-        ctx.transform.apply(ctx, this.canvas.viewportTransform);
-        this.transform(ctx);
-      }
-      else {
-        ctx = this.ctx;
-        ctx.save();
-      }
-
-      if (this.selectionStart === this.selectionEnd) {
-        boundaries = this._getCursorBoundaries(chars, 'cursor');
-        this.renderCursor(boundaries, ctx);
-      }
-      else {
-        boundaries = this._getCursorBoundaries(chars, 'selection');
-        this.renderSelection(chars, boundaries, ctx);
-      }
-
-      ctx.restore();
+      // No, don't do that. We have a real textarea for editing.
     },
 
     /**

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -307,9 +307,12 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _render: function(ctx) {
-      this.callSuper('_render', ctx);
-      this.ctx = ctx;
-      this.isEditing && this.renderCursorOrSelection();
+      // We are now using a native text area to edit text, which will have a transparent background,
+      // so we don't want to render anything to the canvas when we're in edit mode.
+      if (!this.isEditing) {
+        this.callSuper('_render', ctx);
+        this.ctx = ctx;
+      }
     },
 
     /**


### PR DESCRIPTION
- Make textarea background transparent.
- Don't render text when editing, now that text area background would let us see it!
- Constant vertical fudge factor to line up rendering better.
- Multiply font size by other itext scale factor to make lines line up vertically.
