### PR TITLE
[#93496140] Do NOT clear the selection for objects in groups

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -320,7 +320,6 @@
         ||
         (target &&
           activeGroup &&
-          !activeGroup.contains(target) &&
           activeGroup !== target &&
           !e.shiftKey)
         ||


### PR DESCRIPTION
Fabric actually at one stage must have supported removing objects
from groups as they have code to do it. However, this line breaks
it. Vanilla fabric will also need further patches to allow findTarget
to actually work with the different coordinate systems of objects
inside and outside of groups and the normalizePointer fcn is not
happy. Because we are using fabricPerPixelSelection this is
less of a problem for us.
