### PR TITLE
Faster group contains object check in selections

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -268,7 +268,7 @@
           isObjectInGroup = (
             activeGroup &&
             object.type !== 'group' &&
-            activeGroup.contains(object)),
+            object.group === activeGroup),
           lt;
 
       if (isObjectInGroup) {


### PR DESCRIPTION
O(1) instead of O(n) when using the mouse on group selections
