### PR TITLE
[#97068140] Don't wrap inside words.

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -57,8 +57,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       var top = (this.getCenterPoint().y - 0.5 * this.height) * yScale;
       var left = (this.getCenterPoint().x - 0.5 * this.width) * xScale;
       var width = this.getWidth() * xScale;
-      var heightFudgeFactor = this.fontSize * xScale;
-      var height = (this._measuredHeight || this.getHeight()) * yScale + heightFudgeFactor;
+      var height = this.getHeight() * yScale;
 
       this.hiddenTextarea.style.width = width + 'px';
       this.hiddenTextarea.style.height = height + 'px';


### PR DESCRIPTION
Instead, if a word can't even fit on its own line, just let it
overflow beyond the horizontal bounds of the shape.

This has the dual benefits of not mangling your text (really, wh
en are you going to be pleased by having your word broken in the
middle?) and entirely avoids the crazy ~exponential-time algorithm
that implemented that behaviour.

The main downside of this is that the appearance of text while
editing is now more often different from how it will render once
you stop editing. The few people that were involved in playing
with this change (KJ, DRP, JP, RM-ish) were reasonably convinced
that this is an acceptable compromise.
