### PR TITLE
[#93615274] Preserve stroke width on paths

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -503,6 +503,11 @@
       transform.newScaleX = localMouse.x / (target.width + strokeWidth / 2);
       transform.newScaleY = localMouse.y / (target.height + strokeWidth / 2);
 
+      // If what we're scaling is a path group, update the amount by which stroke needs
+      // to be de-scaled on render
+      transform.strokeScaledX = localMouse.x / (target.width + strokeWidth / 2);
+      transform.strokeScaledY = localMouse.y / (target.height + strokeWidth / 2);
+
       if (lockScalingFlip && transform.newScaleX <= 0 && transform.newScaleX < target.scaleX) {
         forbidScalingX = true;
       }
@@ -518,14 +523,34 @@
         this._scaleObjectEqually(localMouse, target, transform, lockScalingFlip);
       }
       else if (!by) {
-        forbidScalingX || lockScalingX || target.set('scaleX', transform.newScaleX);
-        forbidScalingY || lockScalingY || target.set('scaleY', transform.newScaleY);
+        if (!forbidScalingX && !lockScalingX) {
+          target.set('scaleX', transform.newScaleX);
+          if (target.shouldDescaleStroke) {
+            target.set('strokeScaledX', transform.strokeScaledX);
+          }
+        }
+        if (!forbidScalingY && !lockScalingY) {
+          target.set('scaleY', transform.newScaleY);
+          if (target.shouldDescaleStroke) {
+            target.set('strokeScaledY', transform.strokeScaledY);
+          }
+        }
       }
       else if (by === 'x' && !target.get('lockUniScaling')) {
-        forbidScalingX || lockScalingX || target.set('scaleX', transform.newScaleX);
+        if (!forbidScalingX && !lockScalingX) {
+          target.set('scaleX', transform.newScaleX);
+          if (target.shouldDescaleStroke) {
+            target.set('strokeScaledX', transform.strokeScaledX);
+          }
+        }
       }
       else if (by === 'y' && !target.get('lockUniScaling')) {
-        forbidScalingY || lockScalingY || target.set('scaleY', transform.newScaleY);
+        if (!forbidScalingY && !lockScalingY) {
+          target.set('scaleY', transform.newScaleY);
+          if (target.shouldDescaleStroke) {
+            target.set('strokeScaledY', transform.strokeScaledY);
+          }
+        }
       }
 
       forbidScalingX || forbidScalingY || this._flipObject(transform, by);
@@ -552,8 +577,18 @@
       transform.newScaleX = transform.original.scaleX * dist / lastDist;
       transform.newScaleY = transform.original.scaleY * dist / lastDist;
 
+      var lastStrokeScaledDist = (target.height + (strokeWidth / 2)) * target.strokeScaledY +
+                     (target.width + (strokeWidth / 2)) * target.strokeScaledX;
+
+      transform.strokeScaledX = target.strokeScaledX * dist / lastStrokeScaledDist;
+      transform.strokeScaledY = target.strokeScaledY * dist / lastStrokeScaledDist;
+
       target.set('scaleX', transform.newScaleX);
       target.set('scaleY', transform.newScaleY);
+      if (target.shouldDescaleStroke) {
+        target.set('strokeScaledX', transform.strokeScaledX);
+        target.set('strokeScaledY', transform.strokeScaledY);
+      }
     },
 
     /**

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -124,15 +124,28 @@
       else if (hLine) {
         h = strokeWidth;
       }
-      if (strokeW) {
-        w += (w < 0 ? -strokeWidth : strokeWidth);
+
+      var wStrokeMult = this.scaleX / this.strokeScaledX,
+        hStrokeMult = this.scaleY / this.strokeScaledY,
+        boxStrokeWidth = 0,
+        boxStrokeHeight = 0;
+
+      if (!isFinite(wStrokeMult)) {
+        wStrokeMult = 0;
       }
-      if (strokeH) {
-        h += (h < 0 ? -strokeWidth : strokeWidth);
+      if (!isFinite(hStrokeMult)) {
+        hStrokeMult = 0;
       }
 
-      w = w * this.scaleX + 2 * this.padding;
-      h = h * this.scaleY + 2 * this.padding;
+      if (strokeW) {
+        boxStrokeWidth = (w < 0 ? -strokeWidth : strokeWidth) * wStrokeMult;
+      }
+      if (strokeH) {
+        boxStrokeHeight = (h < 0 ? -strokeWidth : strokeWidth) * hStrokeMult;
+      }
+
+      w = w * this.scaleX + boxStrokeWidth + 2 * this.padding;
+      h = h * this.scaleY + boxStrokeHeight + 2 * this.padding;
 
       if (shouldTransform) {
         return fabric.util.transformPoint(new fabric.Point(w, h), vpt, true);

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -124,21 +124,15 @@
       else if (hLine) {
         h = strokeWidth;
       }
-
-      var wStrokeMult = this.transformStrokeAndFill ? this.scaleX : 1,
-        hStrokeMult = this.transformStrokeAndFill ? this.scaleY : 1,
-        boxStrokeWidth = 0,
-        boxStrokeHeight = 0;
-
       if (strokeW) {
-        boxStrokeWidth = (w < 0 ? -strokeWidth : strokeWidth) * wStrokeMult;
+        w += (w < 0 ? -strokeWidth : strokeWidth);
       }
       if (strokeH) {
-        boxStrokeHeight = (h < 0 ? -strokeWidth : strokeWidth) * hStrokeMult;
+        h += (h < 0 ? -strokeWidth : strokeWidth);
       }
 
-      w = w * this.scaleX + boxStrokeWidth + 2 * this.padding;
-      h = h * this.scaleY + boxStrokeHeight + 2 * this.padding;
+      w = w * this.scaleX + 2 * this.padding;
+      h = h * this.scaleY + 2 * this.padding;
 
       if (shouldTransform) {
         return fabric.util.transformPoint(new fabric.Point(w, h), vpt, true);

--- a/src/mixins/object_origin.mixin.js
+++ b/src/mixins/object_origin.mixin.js
@@ -14,20 +14,29 @@
     translateToCenterPoint: function(point, originX, originY) {
       var cx = point.x,
           cy = point.y,
-          strokeWidth = this.stroke ? this.strokeWidth : 0;
+          strokeWidth = this.stroke ? this.strokeWidth : 0,
+          strokeScaleFactorX = this.scaleX / this.strokeScaledX,
+          strokeScaleFactorY = this.scaleY / this.strokeScaledY;
+
+      if (!isFinite(strokeScaleFactorX)) {
+        strokeScaleFactorX = 0;
+      }
+      if (!isFinite(strokeScaleFactorY)) {
+        strokeScaleFactorY = 0;
+      }
 
       if (originX === 'left') {
-        cx = point.x + (this.getWidth() + strokeWidth * this.scaleX) / 2;
+        cx = point.x + (this.getWidth() + strokeWidth * strokeScaleFactorX) / 2;
       }
       else if (originX === 'right') {
-        cx = point.x - (this.getWidth() + strokeWidth * this.scaleX) / 2;
+        cx = point.x - (this.getWidth() + strokeWidth * strokeScaleFactorX) / 2;
       }
 
       if (originY === 'top') {
-        cy = point.y + (this.getHeight() + strokeWidth * this.scaleY) / 2;
+        cy = point.y + (this.getHeight() + strokeWidth * strokeScaleFactorY) / 2;
       }
       else if (originY === 'bottom') {
-        cy = point.y - (this.getHeight() + strokeWidth * this.scaleY) / 2;
+        cy = point.y - (this.getHeight() + strokeWidth * strokeScaleFactorY) / 2;
       }
 
       // Apply the reverse rotation to the point (it's already scaled properly)
@@ -44,20 +53,29 @@
     translateToOriginPoint: function(center, originX, originY) {
       var x = center.x,
           y = center.y,
-          strokeWidth = this.stroke ? this.strokeWidth : 0;
+          strokeWidth = this.stroke ? this.strokeWidth : 0,
+          strokeScaleFactorX = this.scaleX / this.strokeScaledX,
+          strokeScaleFactorY = this.scaleY / this.strokeScaledY;
+
+      if (!isFinite(strokeScaleFactorX)) {
+        strokeScaleFactorX = 0;
+      }
+      if (!isFinite(strokeScaleFactorY)) {
+        strokeScaleFactorY = 0;
+      }
 
       // Get the point coordinates
       if (originX === 'left') {
-        x = center.x - (this.getWidth() + strokeWidth * this.scaleX) / 2;
+        x = center.x - (this.getWidth() + strokeWidth * strokeScaleFactorX) / 2;
       }
       else if (originX === 'right') {
-        x = center.x + (this.getWidth() + strokeWidth * this.scaleX) / 2;
+        x = center.x + (this.getWidth() + strokeWidth * strokeScaleFactorX) / 2;
       }
       if (originY === 'top') {
-        y = center.y - (this.getHeight() + strokeWidth * this.scaleY) / 2;
+        y = center.y - (this.getHeight() + strokeWidth * strokeScaleFactorY) / 2;
       }
       else if (originY === 'bottom') {
-        y = center.y + (this.getHeight() + strokeWidth * this.scaleY) / 2;
+        y = center.y + (this.getHeight() + strokeWidth * strokeScaleFactorY) / 2;
       }
 
       // Apply the rotation to the point (it's already scaled properly)
@@ -103,24 +121,33 @@
     toLocalPoint: function(point, originX, originY) {
       var center = this.getCenterPoint(),
           strokeWidth = this.stroke ? this.strokeWidth : 0,
-          x, y;
+          x, y,
+          strokeScaleFactorX = this.scaleX / this.strokeScaledX,
+          strokeScaleFactorY = this.scaleY / this.strokeScaledY;
+
+      if (!isFinite(strokeScaleFactorX)) {
+        strokeScaleFactorX = 0;
+      }
+      if (!isFinite(strokeScaleFactorY)) {
+        strokeScaleFactorY = 0;
+      }
 
       if (originX && originY) {
         if (originX === 'left') {
-          x = center.x - (this.getWidth() + strokeWidth * this.scaleX) / 2;
+          x = center.x - (this.getWidth() + strokeWidth * strokeScaleFactorX) / 2;
         }
         else if (originX === 'right') {
-          x = center.x + (this.getWidth() + strokeWidth * this.scaleX) / 2;
+          x = center.x + (this.getWidth() + strokeWidth * strokeScaleFactorX) / 2;
         }
         else {
           x = center.x;
         }
 
         if (originY === 'top') {
-          y = center.y - (this.getHeight() + strokeWidth * this.scaleY) / 2;
+          y = center.y - (this.getHeight() + strokeWidth * strokeScaleFactorY) / 2;
         }
         else if (originY === 'bottom') {
-          y = center.y + (this.getHeight() + strokeWidth * this.scaleY) / 2;
+          y = center.y + (this.getHeight() + strokeWidth * strokeScaleFactorY) / 2;
         }
         else {
           y = center.y;

--- a/src/mixins/object_origin.mixin.js
+++ b/src/mixins/object_origin.mixin.js
@@ -14,22 +14,20 @@
     translateToCenterPoint: function(point, originX, originY) {
       var cx = point.x,
           cy = point.y,
-          strokeWidth = this.stroke ? this.strokeWidth : 0,
-          strokeScaleFactorX = this.transformStrokeAndFill ? this.scaleX : 1,
-          strokeScaleFactorY = this.transformStrokeAndFill ? this.scaleY : 1;
+          strokeWidth = this.stroke ? this.strokeWidth : 0;
 
       if (originX === 'left') {
-        cx = point.x + (this.getWidth() + strokeWidth * strokeScaleFactorX) / 2;
+        cx = point.x + (this.getWidth() + strokeWidth * this.scaleX) / 2;
       }
       else if (originX === 'right') {
-        cx = point.x - (this.getWidth() + strokeWidth * strokeScaleFactorX) / 2;
+        cx = point.x - (this.getWidth() + strokeWidth * this.scaleX) / 2;
       }
 
       if (originY === 'top') {
-        cy = point.y + (this.getHeight() + strokeWidth * strokeScaleFactorY) / 2;
+        cy = point.y + (this.getHeight() + strokeWidth * this.scaleY) / 2;
       }
       else if (originY === 'bottom') {
-        cy = point.y - (this.getHeight() + strokeWidth * strokeScaleFactorY) / 2;
+        cy = point.y - (this.getHeight() + strokeWidth * this.scaleY) / 2;
       }
 
       // Apply the reverse rotation to the point (it's already scaled properly)
@@ -46,22 +44,20 @@
     translateToOriginPoint: function(center, originX, originY) {
       var x = center.x,
           y = center.y,
-          strokeWidth = this.stroke ? this.strokeWidth : 0,
-          strokeScaleFactorX = this.transformStrokeAndFill ? this.scaleX : 1,
-          strokeScaleFactorY = this.transformStrokeAndFill ? this.scaleY : 1;
+          strokeWidth = this.stroke ? this.strokeWidth : 0;
 
       // Get the point coordinates
       if (originX === 'left') {
-        x = center.x - (this.getWidth() + strokeWidth * strokeScaleFactorX) / 2;
+        x = center.x - (this.getWidth() + strokeWidth * this.scaleX) / 2;
       }
       else if (originX === 'right') {
-        x = center.x + (this.getWidth() + strokeWidth * strokeScaleFactorX) / 2;
+        x = center.x + (this.getWidth() + strokeWidth * this.scaleX) / 2;
       }
       if (originY === 'top') {
-        y = center.y - (this.getHeight() + strokeWidth * strokeScaleFactorY) / 2;
+        y = center.y - (this.getHeight() + strokeWidth * this.scaleY) / 2;
       }
       else if (originY === 'bottom') {
-        y = center.y + (this.getHeight() + strokeWidth * strokeScaleFactorY) / 2;
+        y = center.y + (this.getHeight() + strokeWidth * this.scaleY) / 2;
       }
 
       // Apply the rotation to the point (it's already scaled properly)
@@ -107,26 +103,24 @@
     toLocalPoint: function(point, originX, originY) {
       var center = this.getCenterPoint(),
           strokeWidth = this.stroke ? this.strokeWidth : 0,
-          x, y,
-          strokeScaleFactorX = this.transformStrokeAndFill ? this.scaleX : 1,
-          strokeScaleFactorY = this.transformStrokeAndFill ? this.scaleY : 1;
+          x, y;
 
       if (originX && originY) {
         if (originX === 'left') {
-          x = center.x - (this.getWidth() + strokeWidth * strokeScaleFactorX) / 2;
+          x = center.x - (this.getWidth() + strokeWidth * this.scaleX) / 2;
         }
         else if (originX === 'right') {
-          x = center.x + (this.getWidth() + strokeWidth * strokeScaleFactorX) / 2;
+          x = center.x + (this.getWidth() + strokeWidth * this.scaleX) / 2;
         }
         else {
           x = center.x;
         }
 
         if (originY === 'top') {
-          y = center.y - (this.getHeight() + strokeWidth * strokeScaleFactorY) / 2;
+          y = center.y - (this.getHeight() + strokeWidth * this.scaleY) / 2;
         }
         else if (originY === 'bottom') {
-          y = center.y + (this.getHeight() + strokeWidth * strokeScaleFactorY) / 2;
+          y = center.y + (this.getHeight() + strokeWidth * this.scaleY) / 2;
         }
         else {
           y = center.y;

--- a/src/shapes/ellipse.class.js
+++ b/src/shapes/ellipse.class.js
@@ -42,13 +42,6 @@
     ry:   0,
 
     /**
-     * When false, the stroke will always drawn the same width, regardless of scaleX and scaleY.
-     * @type Boolean
-     * @default
-     */
-    transformStrokeAndFill: true,
-
-    /**
      * Constructor
      * @param {Object} [options] Options object
      * @return {fabric.Ellipse} thisArg
@@ -146,7 +139,7 @@
      * @param {CanvasRenderingContext2D} ctx context to render on
      * @param {Boolean} [noTransform] When true, context is not transformed
      */
-    _createPath: function(ctx, noTransform) {
+    _render: function(ctx, noTransform) {
       ctx.beginPath();
       ctx.save();
       ctx.transform(1, 0, 0, this.ry/this.rx, 0, 0);
@@ -158,56 +151,8 @@
         piBy2,
         false);
       ctx.restore();
-    },
-
-    _renderCurrentPath: function(ctx) {
       this._renderFill(ctx);
       this._renderStroke(ctx);
-    },
-
-    /**
-     * Renders an object on a specified context
-     * @param {CanvasRenderingContext2D} ctx Context to render on
-     * @param {Boolean} [noTransform] When true, context is not transformed
-     */
-    render: function(ctx, noTransform) {
-      // do not render if width/height are zeros or object is not visible
-      if (this.width === 0 || this.height === 0 || !this.visible) {
-        return;
-      }
-
-      ctx.save();
-
-      !this.transformStrokeAndFill && ctx.save();
-      if (!noTransform) {
-        this.transform(ctx);
-      }
-      if (this.transformMatrix) {
-        ctx.transform.apply(ctx, this.transformMatrix);
-      }
-      this._createPath(ctx, noTransform);
-      !this.transformStrokeAndFill && ctx.restore();
-
-      // Pop contexts to remove scaling applied by the PathGroup
-      if (!this.transformStrokeAndFill && this.group && this.group.type === 'path-group') {
-        ctx.restore();  // ctx.save at the top of this function.
-        ctx.restore();  // ctx.save in PathGroup - we're not distorted now. PathGroup has been hacked to expect this.
-        ctx.save();     // Make a new context so PathGroup has something to restore.
-        ctx.save();     // Emulate ctx.save at the top of this function
-      }
-
-      this._setupCompositeOperation(ctx);
-      this._setStrokeStyles(ctx);
-      this._setFillStyles(ctx);
-      this._setOpacity(ctx);
-      this._setShadow(ctx);
-      this.clipTo && fabric.util.clipContext(this, ctx);
-      this._renderCurrentPath(ctx);
-      this.clipTo && ctx.restore();
-      this._removeShadow(ctx);
-      this._restoreCompositeOperation(ctx);
-
-      ctx.restore();
     },
 
     /**

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1154,11 +1154,11 @@
 
         ctx.save();
         if (this.group && this.group.shouldDescaleStroke) {
-            if (!isNaN(1/this.group.strokeScaledX) && !isNaN(1/this.group.strokeScaledY)) {
+            if (isFinite(1/this.group.strokeScaledX) && isFinite(1/this.group.strokeScaledY)) {
                 ctx.scale(1/this.group.strokeScaledX, 1/this.group.strokeScaledY);
             }
         } else if (this.shouldDescaleStroke) {
-            if (!isNaN(1/this.strokeScaledX) && !isNaN(1/this.strokeScaledY)) {
+            if (isFinite(1/this.strokeScaledX) && isFinite(1/this.strokeScaledY)) {
                 ctx.scale(1/this.strokeScaledX, 1/this.strokeScaledY);
             }
         }

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -354,6 +354,11 @@
      */
     scaleY:                   1,
 
+    // Hack to be able to know how much to invert stroke transforms.
+    strokeScaledX: 1,
+    strokeScaledY: 1,
+    shouldDescaleStroke: false,
+
     /**
      * When true, an object is rendered as flipped horizontally
      * @type Boolean
@@ -1146,7 +1151,21 @@
           var g = this.stroke.gradientTransform;
           ctx.transform.apply(ctx, g);
         }
+
+        ctx.save();
+        if (this.group && this.group.shouldDescaleStroke) {
+            if (!isNaN(1/this.group.strokeScaledX) && !isNaN(1/this.group.strokeScaledY)) {
+                ctx.scale(1/this.group.strokeScaledX, 1/this.group.strokeScaledY);
+            }
+        } else if (this.shouldDescaleStroke) {
+            if (!isNaN(1/this.strokeScaledX) && !isNaN(1/this.strokeScaledY)) {
+                ctx.scale(1/this.strokeScaledX, 1/this.strokeScaledY);
+            }
+        }
+
         this._stroke ? this._stroke(ctx) : ctx.stroke();
+
+        ctx.restore();
       }
       this._removeShadow(ctx);
       ctx.restore();

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -66,6 +66,9 @@
      */
     minY: 0,
 
+    // Apply path width normalisation to the stroke width
+    shouldDescaleStroke: true,
+
     /**
      * Constructor
      * @param {Array|String} path Path data (sequence of coordinates and corresponding "command" tokens)

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -67,13 +67,6 @@
     minY: 0,
 
     /**
-     * When false, the stroke will always drawn the same width, regardless of scaleX and scaleY.
-     * @type Boolean
-     * @default
-     */
-    transformStrokeAndFill: true,
-
-    /**
      * Constructor
      * @param {Array|String} path Path data (sequence of coordinates and corresponding "command" tokens)
      * @param {Object} [options] Options object
@@ -146,9 +139,9 @@
 
     /**
      * @private
-     * @param {CanvasRenderingContext2D} ctx context to create path on
+     * @param {CanvasRenderingContext2D} ctx context to render path on
      */
-    _createPath: function(ctx) {
+    _render: function(ctx) {
       var current, // current instruction
           previous = null,
           subpathStartX = 0,
@@ -453,56 +446,8 @@
         }
         previous = current;
       }
-    },
-
-    _renderCurrentPath: function(ctx) {
       this._renderFill(ctx);
       this._renderStroke(ctx);
-    },
-
-    /**
-     * Renders path on a specified context
-     * @param {CanvasRenderingContext2D} ctx context to render path on
-     * @param {Boolean} [noTransform] When true, context is not transformed
-     */
-    render: function(ctx, noTransform) {
-      // do not render if width/height are zeros or object is not visible
-      if (!this.visible) {
-        return;
-      }
-
-      ctx.save();
-
-      !this.transformStrokeAndFill && ctx.save();
-      if (!noTransform) {
-        this.transform(ctx);
-      }
-      if (this.transformMatrix) {
-        ctx.transform.apply(ctx, this.transformMatrix);
-      }
-      this._createPath(ctx, noTransform);
-      !this.transformStrokeAndFill && ctx.restore();
-
-      // Pop contexts to remove scaling applied by the PathGroup
-      if (!this.transformStrokeAndFill && this.group && this.group.type === 'path-group') {
-        ctx.restore();  // ctx.save at the top of this function.
-        ctx.restore();  // ctx.save in PathGroup - we're not distorted now. PathGroup has been hacked to expect this.
-        ctx.save();     // Make a new context so PathGroup has something to restore.
-        ctx.save();     // Emulate ctx.save at the top of this function
-      }
-
-      this._setupCompositeOperation(ctx);
-      this._setStrokeStyles(ctx);
-      this._setFillStyles(ctx);
-      this._setOpacity(ctx);
-      this._setShadow(ctx);
-      this.clipTo && fabric.util.clipContext(this, ctx);
-      this._renderCurrentPath(ctx);
-      this.clipTo && ctx.restore();
-      this._removeShadow(ctx);
-      this._restoreCompositeOperation(ctx);
-
-      ctx.restore();
     },
 
     /**

--- a/src/shapes/path_group.class.js
+++ b/src/shapes/path_group.class.js
@@ -101,19 +101,22 @@
         return;
       }
 
-      for (var i = 0, l = this.paths.length; i < l; ++i) {
-        ctx.save();
+      ctx.save();
 
-        if (this.transformMatrix) {
-          ctx.transform.apply(ctx, this.transformMatrix);
-        }
-        this.transform(ctx);
-        ctx.translate(-this.width/2, -this.height/2);
-
-        this.paths[i].render(ctx, true);
-
-        ctx.restore();
+      if (this.transformMatrix) {
+        ctx.transform.apply(ctx, this.transformMatrix);
       }
+      this.transform(ctx);
+
+      this._setShadow(ctx);
+      this.clipTo && fabric.util.clipContext(this, ctx);
+      ctx.translate(-this.width/2, -this.height/2);
+      for (var i = 0, l = this.paths.length; i < l; ++i) {
+        this.paths[i].render(ctx, true);
+      }
+      this.clipTo && ctx.restore();
+      this._removeShadow(ctx);
+      ctx.restore();
     },
 
     /**

--- a/src/shapes/path_group.class.js
+++ b/src/shapes/path_group.class.js
@@ -35,6 +35,9 @@
      */
     fill: '',
 
+    // Apply the stroke width normalisation to stuff in here
+    shouldDescaleStroke: true,
+
     /**
      * Constructor
      * @param {Array} paths

--- a/src/shapes/polygon.class.js
+++ b/src/shapes/polygon.class.js
@@ -50,13 +50,6 @@
     minY: 0,
 
     /**
-     * When false, the stroke will always drawn the same width, regardless of scaleX and scaleY.
-     * @type Boolean
-     * @default
-     */
-    transformStrokeAndFill: true,
-
-    /**
      * Constructor
      * @param {Array} points Array of points
      * @param {Object} [options] Options object
@@ -147,14 +140,10 @@
      * @private
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
-    _createPath: function(ctx) {
+    _render: function(ctx) {
       if (!this.commonRender(ctx)) {
         return;
       }
-      this.commonRender(ctx);
-    },
-
-    _renderCurrentPath: function(ctx) {
       this._renderFill(ctx);
       if (this.stroke || this.strokeDashArray) {
         ctx.closePath();
@@ -199,51 +188,6 @@
     _renderDashedStroke: function(ctx) {
       fabric.Polyline.prototype._renderDashedStroke.call(this, ctx);
       ctx.closePath();
-    },
-
-    /**
-     * Renders an object on a specified context
-     * @param {CanvasRenderingContext2D} ctx Context to render on
-     * @param {Boolean} [noTransform] When true, context is not transformed
-     */
-    render: function(ctx, noTransform) {
-      // do not render if width/height are zeros or object is not visible
-      if (this.width === 0 || this.height === 0 || !this.visible) {
-        return;
-      }
-
-      ctx.save();
-
-      !this.transformStrokeAndFill && ctx.save();
-      if (!noTransform) {
-        this.transform(ctx);
-      }
-      if (this.transformMatrix) {
-        ctx.transform.apply(ctx, this.transformMatrix);
-      }
-      this._createPath(ctx, noTransform);
-      !this.transformStrokeAndFill && ctx.restore();
-
-      // Pop contexts to remove scaling applied by the PathGroup
-      if (!this.transformStrokeAndFill && this.group && this.group.type === 'path-group') {
-        ctx.restore();  // ctx.save at the top of this function.
-        ctx.restore();  // ctx.save in PathGroup - we're not distorted now. PathGroup has been hacked to expect this.
-        ctx.save();     // Make a new context so PathGroup has something to restore.
-        ctx.save();     // Emulate ctx.save at the top of this function
-      }
-
-      this._setupCompositeOperation(ctx);
-      this._setStrokeStyles(ctx);
-      this._setFillStyles(ctx);
-      this._setOpacity(ctx);
-      this._setShadow(ctx);
-      this.clipTo && fabric.util.clipContext(this, ctx);
-      this._renderCurrentPath(ctx);
-      this.clipTo && ctx.restore();
-      this._removeShadow(ctx);
-      this._restoreCompositeOperation(ctx);
-
-      ctx.restore();
     },
 
     /**


### PR DESCRIPTION
This PR adds an option to preserve stroke width on paths & path groups, when applied via the drag handles. It is NOT done for scale added via the group selection. This means you can make entire swathes of objects bigger or smaller, but moving the handles on a single object effectively resizes it.
