### PR TITLE
[#97632112] Improve stroke width preservation under resize

### DIFF
--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -240,14 +240,12 @@
      * @return {Number}
      */
     _constrainScale: function(value) {
-      if (Math.abs(value) < this.minScaleLimit) {
-        if (value < 0) {
-          return -this.minScaleLimit;
-        }
-        else {
-          return this.minScaleLimit;
-        }
-      }
+      // This function has been removed.
+      // There is now no such thing as a minimum object size.
+      // Users must fight this footgun with the undo button.
+      // This feature was causing real badness when objects were made small;
+      // the stroke was growing obsenely and painting the entire screen
+      // the colour of the stroke.
       return value;
     },
 

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1153,13 +1153,21 @@
         }
 
         ctx.save();
+
+        // Find out if we should be applying a cancelling transform to our stroke
+        var strokeDescaleObject = null;
         if (this.group && this.group.shouldDescaleStroke) {
-            if (isFinite(1/this.group.strokeScaledX) && isFinite(1/this.group.strokeScaledY)) {
-                ctx.scale(1/this.group.strokeScaledX, 1/this.group.strokeScaledY);
-            }
+            strokeDescaleObject = this.group;
         } else if (this.shouldDescaleStroke) {
-            if (isFinite(1/this.strokeScaledX) && isFinite(1/this.strokeScaledY)) {
-                ctx.scale(1/this.strokeScaledX, 1/this.strokeScaledY);
+            strokeDescaleObject = this;
+        }
+
+        if (strokeDescaleObject) {
+            // Don't bother descaling the stroke where the factor is large
+            // You wind up with all sorts of totally busted states because of
+            // floating point precision.
+            if (isFinite(1/strokeDescaleObject.strokeScaledX) && isFinite(1/strokeDescaleObject.strokeScaledY)) {
+                ctx.scale(1/strokeDescaleObject.strokeScaledX, 1/strokeDescaleObject.strokeScaledY);
             }
         }
 


### PR DESCRIPTION
There were still a number of cases that could cause the stroke width of an object to unexpectedly grow during resize (of a single object), or to simply go bananas when objects are made small and cover the entire canvas in stroke. This PR fixes that by making the stroke width antiscaling calculation behave more like the actual scaling calculation. There is also extra defensiveness around division by zero (since this can cause an object to become unusable forever).
