### PR TITLE
Group selection deselection

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -250,16 +250,17 @@
      * @return {Boolean} true if point is contained within an area of given object
      */
     containsPoint: function (e, target) {
+      //TODO delete this!
       var pointer = this.getPointer(e, true),
           xy = this._normalizePointer(target, pointer);
-
       // http://www.geog.ubc.ca/courses/klink/gis.notes/ncgia/u32.html
       // http://idav.ucdavis.edu/~okreylos/TAship/Spring2000/PointInPolygon.html
       return (target.containsPoint(xy) || target._findTargetCorner(pointer));
     },
 
     /**
-     * @private
+     * //TODO delete this!
+     * @private This method is used only inside containsPoint
      */
     _normalizePointer: function (object, pointer) {
       var activeGroup = this.getActiveGroup(),
@@ -769,7 +770,7 @@
         this.controlsAboveOverlay &&
         this.lastRenderedObjectWithControlsAboveOverlay &&
         this.lastRenderedObjectWithControlsAboveOverlay.visible &&
-        this.containsPoint(e, this.lastRenderedObjectWithControlsAboveOverlay) &&
+        this.containsPoint(e, this.lastRenderedObjectWithControlsAboveOverlay, false) &&
         this.lastRenderedObjectWithControlsAboveOverlay._findTargetCorner(this.getPointer(e, true)));
     },
 
@@ -783,18 +784,28 @@
         return;
       }
 
-      if (this._isLastRenderedObject(e)) {
+      //an optimization for making mouse move events over an active group 
+      //or object have a fast path
+      if (!skipGroup && this._isLastRenderedObject(e)) {
         return this.lastRenderedObjectWithControlsAboveOverlay;
       }
 
       // first check current group (if one exists)
       var activeGroup = this.getActiveGroup();
-      if (activeGroup && !skipGroup && this.containsPoint(e, activeGroup)) {
+      if (!skipGroup && activeGroup && this.containsPoint(e, activeGroup, false)) {
         return activeGroup;
       }
 
-      var target = this._searchPossibleTargets(e);
-      this._fireOverOutEvents(target, e);
+      var target;
+      if(!skipGroup) {
+        target = this._searchPossibleTargets(e);
+        this._fireOverOutEvents(target, e);
+      }
+      else if(activeGroup) {
+        //we have clicked a group, we are now looking explicitly looking inside the group
+        target = this._searchPossibleTargets(e, activeGroup);
+        this._fireOverOutEvents(target, e);
+      }
 
       return target;
     },
@@ -822,7 +833,7 @@
     },
 
     /**
-     * @private
+     * @private //TODO delete this!
      */
     _checkTarget: function(e, obj, pointer) {
       if (obj &&
@@ -842,10 +853,9 @@
     },
 
     /**
-     * @private
+     * @private //TODO delete this!
      */
     _searchPossibleTargets: function(e) {
-
       // Cache all targets where their bounding box contains point.
       var target,
           pointer = this.getPointer(e, true),

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -707,15 +707,6 @@
     /**
      * @private
      */
-    _resetObjectTransform: function (target) {
-      target.scaleX = 1;
-      target.scaleY = 1;
-      target.setAngle(0);
-    },
-
-    /**
-     * @private
-     */
     _drawSelection: function () {
       var ctx = this.contextTop,
           groupSelector = this._groupSelector,

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -791,10 +791,13 @@
       if(!skipGroup) {
         target = this._searchPossibleTargets(e);
         this._fireOverOutEvents(target, e);
-      }
-      else if(activeGroup) {
+      } else if(activeGroup) {
         //we have clicked a group, we are now looking explicitly looking inside the group
         target = this._searchPossibleTargets(e, activeGroup);
+        if(!target) {
+          //there was nothing in the group clicked, let's try objects overlapping the group
+          target = this._searchPossibleTargets(e);
+        }
         this._fireOverOutEvents(target, e);
       }
 

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -421,7 +421,8 @@
         return;
       }
 
-      var target = this.findTarget(e),
+      //initially look for objects or groups
+      var target = this.findTarget(e, false),
           pointer = this.getPointer(e, true);
 
       // save pointer for check in __onMouseUp event

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -59,7 +59,6 @@
       if (activeGroup.contains(target)) {
 
         activeGroup.removeWithUpdate(target);
-        this._resetObjectTransform(activeGroup);
         target.set('active', false);
 
         if (activeGroup.size() === 1) {
@@ -72,7 +71,6 @@
       }
       else if (this._maybeAddToGroup(target)) {
         activeGroup.addWithUpdate(target);
-        this._resetObjectTransform(activeGroup);
       }
       this.fire('selection:created', { target: activeGroup, e: e });
       activeGroup.set('active', true);

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -129,6 +129,9 @@
       }
       // since _restoreObjectsState set objects inactive
       this.forEachObject(this._setObjectActive, this);
+
+      //reset the scale/angle before updating objectCoords
+      this._resetTransform();
       this._calcBounds();
       this._updateObjectsCoords();
       return this;
@@ -150,15 +153,27 @@
       this._moveFlippedObject(object);
       this._restoreObjectsState();
 
+      this.remove(object);
+
       // since _restoreObjectsState set objects inactive
       this.forEachObject(this._setObjectActive, this);
-
-      this.remove(object);
+      //reset the scale/angle before updating objectCoords
+      this._resetTransform();
       this._calcBounds();
       this._updateObjectsCoords();
 
       return this;
     },
+
+    /**
+     * @private
+     */
+    _resetTransform: function () {
+      this.scaleX = 1;
+      this.scaleY = 1;
+      this.setAngle(0);
+    },
+
     /**
      * @private
      */
@@ -342,7 +357,6 @@
     _restoreObjectState: function(object) {
       this._setObjectPosition(object);
 
-      object.setCoords();
       object.hasControls = object.__origHasControls;
       delete object.__origHasControls;
       object.set('active', false);


### PR DESCRIPTION
This allows adding/removing objects from the selection properly.

Firstly fabric wasn't compensating for coordinates of objects inside of groups, it then had various
control flow problems that prevented the code from executing properly such as a fast path that wouldn't allow 
checking if a click intersected with something inside of a group if another object or the group itself was the last thing rendered.

Also, reseting the transform on the group wasn't being done early enough in addWithUpdate and removeWithUpdate and was causing a horrible jank.
