### PR TITLE
[#97870614] faster drawing

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -261,6 +261,7 @@
         target = this._currentTransform.target;
       }
       else {
+          //TODO not sure this is needed
         target = this.findTarget(e, true);
       }
 
@@ -351,11 +352,6 @@
           pointer = fabric.util.transformPoint(this.getPointer(e, true), ivt);
       this.freeDrawingBrush.onMouseDown(pointer);
       this.fire('mouse:down', { e: e });
-      
-      var target = this.findTarget(e);
-      if (typeof target !== 'undefined') {
-        target.fire('mousedown', { e: e, target: target });
-      }
     },
 
     /**
@@ -370,11 +366,6 @@
       }
       this.setCursor(this.freeDrawingCursor);
       this.fire('mouse:move', { e: e });
-      
-      var target = this.findTarget(e);
-      if (typeof target !== 'undefined') {
-        target.fire('mousemove', { e: e, target: target });
-      }
     },
 
     /**
@@ -388,11 +379,6 @@
       }
       this.freeDrawingBrush.onMouseUp();
       this.fire('mouse:up', { e: e });
-      
-      var target = this.findTarget(e);
-      if (typeof target !== 'undefined') {
-        target.fire('mouseup', { e: e, target: target });
-      }
     },
 
     /**


### PR DESCRIPTION
Fabric sends a bunch of mouse over events when in drawing mode
since we don't care about these, we don't need the _expensive_
findTarget check
