### PR TITLE
[#93604260] Don't break page layout with an offscreen textarea

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -338,12 +338,6 @@
      * @chainable
      */
     enterEditing: function() {
-      // We don't want to allow users to edit text that is mostly offscreen, because the textarea
-      // will end up causing the browser's scroll position to jump around wildly.
-      if (this._isMostlyOffscreen()) {
-        return;
-      }
-
       if (this.isEditing || !this.editable) {
         if(this.hiddenTextarea) {
           this.hiddenTextarea.focus();
@@ -407,28 +401,6 @@
           _this.setSelectionEnd(_this.__selectionStartOnMouseDown);
         }
       });
-    },
-
-    _isMostlyOffscreen: function () {
-      var OFFSCREEN_THRESHOLD = 0.2;
-
-      var artboard = this.canvas.sketchpad._artboard;
-      var thisRight = artboard.width - (this.left + this.width);
-      var thisBottom = artboard.height - (this.top + this.height);
-
-      return (
-        // Left side
-        (this.left < 0 && -this.left / this.width > OFFSCREEN_THRESHOLD) ||
-
-        // Right side
-        (thisRight < 0 && -thisRight / this.width > OFFSCREEN_THRESHOLD) ||
-
-        // Top
-        (this.top < 0 && -this.top / this.height > OFFSCREEN_THRESHOLD) ||
-
-        // Bottom
-        (thisBottom < 0 && -thisBottom / this.height > OFFSCREEN_THRESHOLD)
-      );
     },
 
     /**

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -73,6 +73,35 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       var width = this.getWidth() * xScale;
       var height = this.getHeight() * yScale;
 
+      // Move the textarea to the left, top, bottom, or right as needed in order
+      // to keep the textarea roughly on the canvas.
+      // This has the effect of possibly making the textarea not in the same spot as
+      // the rendered text.
+      // Who cares. It's better than having the browser try and keep the cursor on
+      // the screen, which it does even if clipped away.
+      // Fixes #93604260
+
+      // I'm leaving all of the pointless 0's in the code below to illustrate an important point:
+      // The left/top of the canvasRect in its own coordinate space is 0,0
+      // Therefore, you could consider canvasRect.left === canvasRect.top === 0
+      var topOverflow = Math.max(0 - top, 0);
+      var leftOverflow = Math.max(0 - left, 0);
+      var bottomOverflow = Math.max((top + height) - (0 + canvasRect.height), 0);
+      var rightOverflow = Math.max((left + width) - (0 + canvasRect.width), 0);
+
+      if (topOverflow > 0) {
+        top += topOverflow;
+      }
+      if (bottomOverflow > 0) {
+        top -= bottomOverflow;
+      }
+      if (leftOverflow > 0) {
+        left += leftOverflow;
+      }
+      if (rightOverflow > 0) {
+        left -= rightOverflow;
+      }
+
       this.hiddenTextarea.style.width = width + 'px';
       this.hiddenTextarea.style.height = height + 'px';
       this.hiddenTextarea.style.top = top + 'px';


### PR DESCRIPTION
If the text editing textarea won't fit on the screen where it is, move
it so that it does. This appears to result in some fairly sensible
behavour around the edge of the screens.
