### PR TITLE
[#128922461] Fix group rotation of lines

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -552,7 +552,8 @@
                 ydiff = area.height;
             }
 
-            //setting these directly will also reset the angle of the line
+            // Reset the angle of the line to 0, since we've done all our maths in canvas space
+            target.set("angle", 0);
             if(moveTailEnd) {
                 target.set("x2", constrainedPoint.x);
                 target.set("y2", constrainedPoint.y);

--- a/src/shapes/line.class.js
+++ b/src/shapes/line.class.js
@@ -105,10 +105,6 @@
     _set: function(key, value) {
       this.callSuper('_set', key, value);
       if (typeof coordProps[key] !== 'undefined') {
-        //if we have set x1,x2,y1,y2 then the angle must be
-        //reset, otherwise the next time we calculate x1,x2,y1,y2
-        //we will be rotating the line mistakenly
-        this.angle = 0;
         this._setWidthHeight();
       }
 


### PR DESCRIPTION
Our stileSnappedScaling behaviour does its maths in canvas space and updates (x1,y1,x2,y2) with canvas space coordinates. This means we have to remove any other transformation on the object, otherwise they will be applied to the new coordinates on every change (causing the "flying baton" bug).

We were previously removing the rotation in the setter for the Line, but this meant that any Lines that were actually rotated (only achievable if rotated in a group - a Line can't be rotated by itself) had their rotation stripped during deserialization.
- [x] The submodule in the web-client needs to be updated once this has been merged.
