### PR TITLE
Updated touch detection for Chrome 70

### DIFF
--- a/HEADER.js
+++ b/HEADER.js
@@ -27,7 +27,8 @@ else {
  * True when in environment that supports touch events
  * @type boolean
  */
-fabric.isTouchSupported = "ontouchstart" in fabric.document.documentElement;
+fabric.isTouchSupported = 'ontouchstart' in fabric.window || 'ontouchstart' in fabric.document ||
+  (fabric.window && fabric.window.navigator && fabric.window.navigator.maxTouchPoints > 0);
 
 /**
  * True when in environment that's probably Node.js


### PR DESCRIPTION
Google updated Chrome such that `ontouch*` APIs are by default disabled on desktop (Chrome 70). Rather than have users change their Chrome settings, this update (sourced from: https://github.com/fabricjs/fabric.js/pull/5406) adds additional checks to determine if touch is enabled.